### PR TITLE
Add more Playwright tests for the start page

### DIFF
--- a/app/page.spec.ts
+++ b/app/page.spec.ts
@@ -45,7 +45,9 @@ test("selecting a gif and copying the url", async ({ page, baseUrl }) => {
 
   await clipboard.click();
 
-  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  const clipboardText = await page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
   expect(clipboardText).toContain(
     mockedFeaturedResponse.results[0].media_formats.mediumgif.url,
   );
@@ -105,7 +107,9 @@ test("keyboard navigation of gifs", async ({ page, baseUrl }) => {
 
   await page.keyboard.press("Enter");
 
-  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  const clipboardText = await page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
   expect(clipboardText).toContain(
     mockedFeaturedResponse.results[1].media_formats.mediumgif.url,
   );
@@ -116,7 +120,7 @@ test("keyboard navigation of searching for gifs", async ({ page, baseUrl }) => {
   const tabKey = getTabKey(test);
 
   const searchInput = page.getByRole("textbox", { name: "search" });
-  expect(searchInput).toBeFocused();
+  await expect(searchInput).toBeFocused();
 
   await page.keyboard.insertText("cats");
   await page.keyboard.press(tabKey);

--- a/app/page.spec.ts
+++ b/app/page.spec.ts
@@ -29,7 +29,11 @@ test("initial render", async ({ page, baseUrl }) => {
   await expect(footer).toBeVisible();
 });
 
-test("selecting a gif and copying the url", async ({ page, baseUrl }) => {
+test("selecting a gif and copying the url", async ({
+  page,
+  baseUrl,
+  browserName,
+}) => {
   await page.goto(baseUrl);
 
   const gifs = page.getByRole("button", {
@@ -45,12 +49,15 @@ test("selecting a gif and copying the url", async ({ page, baseUrl }) => {
 
   await clipboard.click();
 
-  const clipboardText = await page.evaluate(() =>
-    navigator.clipboard.readText(),
-  );
-  expect(clipboardText).toContain(
-    mockedFeaturedResponse.results[0].media_formats.mediumgif.url,
-  );
+  // https://github.com/microsoft/playwright/issues/34307
+  if (!(browserName === "webkit" && process.env.CI)) {
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(clipboardText).toContain(
+      mockedFeaturedResponse.results[0].media_formats.mediumgif.url,
+    );
+  }
 });
 
 test("searching for gifs", async ({ page, baseUrl }) => {
@@ -65,9 +72,9 @@ test("searching for gifs", async ({ page, baseUrl }) => {
   await expect(page).toHaveURL(`${baseUrl}/search/cats`);
 });
 
-test("keyboard navigation of gifs", async ({ page, baseUrl }) => {
+test("keyboard navigation of gifs", async ({ page, baseUrl, browserName }) => {
   await page.goto(baseUrl);
-  const tabKey = getTabKey(test);
+  const tabKey = getTabKey(browserName);
 
   const searchInput = page.getByRole("textbox", { name: "search" });
   await expect(searchInput).toBeFocused();
@@ -107,17 +114,24 @@ test("keyboard navigation of gifs", async ({ page, baseUrl }) => {
 
   await page.keyboard.press("Enter");
 
-  const clipboardText = await page.evaluate(() =>
-    navigator.clipboard.readText(),
-  );
-  expect(clipboardText).toContain(
-    mockedFeaturedResponse.results[1].media_formats.mediumgif.url,
-  );
+  // https://github.com/microsoft/playwright/issues/34307
+  if (!(browserName === "webkit" && process.env.CI)) {
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(clipboardText).toContain(
+      mockedFeaturedResponse.results[1].media_formats.mediumgif.url,
+    );
+  }
 });
 
-test("keyboard navigation of searching for gifs", async ({ page, baseUrl }) => {
+test("keyboard navigation of searching for gifs", async ({
+  page,
+  baseUrl,
+  browserName,
+}) => {
   await page.goto(baseUrl);
-  const tabKey = getTabKey(test);
+  const tabKey = getTabKey(browserName);
 
   const searchInput = page.getByRole("textbox", { name: "search" });
   await expect(searchInput).toBeFocused();

--- a/app/page.spec.ts
+++ b/app/page.spec.ts
@@ -1,28 +1,130 @@
 import { expect } from "@playwright/test";
-import { it } from "../src/test/browser/fixtures";
+import { test } from "../src/test/browser/fixtures";
+import { getTabKey } from "../src/test/browser/utils";
+import { mockedFeaturedResponse } from "../src/test/api/tenor/mocks/featuredResponse";
 
-it("renders correctly", async ({ page, baseUrl }) => {
+test("initial render", async ({ page, baseUrl }) => {
   await page.goto(baseUrl);
 
-  // title
   await expect(page).toHaveTitle("gifs.run - the fastest way to share gifs");
 
-  // logo
   const logo = page.getByRole("img", { name: "gifs.run logo" });
   await expect(logo).toBeVisible();
 
-  // search input
   const searchInput = page.getByRole("textbox", { name: "search" });
   await expect(searchInput).toBeVisible();
   await expect(searchInput).toBeEmpty();
   await expect(searchInput).toBeFocused();
   await expect(searchInput).toHaveAttribute("placeholder", "Search for a gif");
 
-  // search button
   const searchButton = page.getByRole("button", { name: "Search" });
   await expect(searchButton).toBeVisible();
 
-  // footer
+  const gifs = page.getByRole("button", {
+    name: /Load full preview of gif with description/,
+  });
+  await expect(gifs).toHaveCount(50);
+
   const footer = page.getByRole("img", { name: "Powered by Tenor" });
   await expect(footer).toBeVisible();
+});
+
+test("selecting a gif and copying the url", async ({ page, baseUrl }) => {
+  await page.goto(baseUrl);
+
+  const gifs = page.getByRole("button", {
+    name: /Load full preview of gif with description/,
+  });
+  const firstGif = gifs.first();
+
+  await firstGif.click();
+
+  const clipboard = page.getByRole("button", {
+    name: "Copy gif share link to clipboard",
+  });
+
+  await clipboard.click();
+
+  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  expect(clipboardText).toContain(
+    mockedFeaturedResponse.results[0].media_formats.mediumgif.url,
+  );
+});
+
+test("searching for gifs", async ({ page, baseUrl }) => {
+  await page.goto(baseUrl);
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  await searchInput.fill("cats");
+
+  const searchButton = page.getByRole("button", { name: "Search" });
+  await searchButton.click();
+
+  await expect(page).toHaveURL(`${baseUrl}/search/cats`);
+});
+
+test("keyboard navigation of gifs", async ({ page, baseUrl }) => {
+  await page.goto(baseUrl);
+  const tabKey = getTabKey(test);
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  await expect(searchInput).toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  const searchButton = page.getByRole("button", { name: "Search" });
+  await expect(searchButton).toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  const gifs = page.getByRole("button", {
+    name: /Load full preview of gif with description/,
+  });
+  const firstGif = gifs.first();
+  await expect(firstGif).toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  const secondGif = gifs.nth(1);
+  await expect(secondGif).toBeFocused();
+
+  const clipboard = page.getByRole("button", {
+    name: "Copy gif share link to clipboard",
+  });
+  await expect(clipboard).not.toBeVisible();
+
+  await page.keyboard.press("Enter");
+
+  await expect(secondGif).toBeFocused();
+  await expect(clipboard).toBeVisible();
+  await expect(clipboard).not.toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  await expect(clipboard).toBeFocused();
+
+  await page.keyboard.press("Enter");
+
+  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  expect(clipboardText).toContain(
+    mockedFeaturedResponse.results[1].media_formats.mediumgif.url,
+  );
+});
+
+test("keyboard navigation of searching for gifs", async ({ page, baseUrl }) => {
+  await page.goto(baseUrl);
+  const tabKey = getTabKey(test);
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  expect(searchInput).toBeFocused();
+
+  await page.keyboard.insertText("cats");
+  await page.keyboard.press(tabKey);
+
+  const searchButton = page.getByRole("button", { name: "Search" });
+  await expect(searchButton).toBeFocused();
+
+  await page.keyboard.press("Enter");
+
+  await expect(page).toHaveURL(`${baseUrl}/search/cats`);
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        permissions: ["clipboard-read", "clipboard-write"],
+      },
     },
     {
       name: "firefox",
@@ -22,7 +25,10 @@ export default defineConfig({
     },
     {
       name: "webkit",
-      use: { ...devices["Desktop Safari"] },
+      use: {
+        ...devices["Desktop Safari"],
+        permissions: ["clipboard-read"],
+      },
     },
   ],
 });

--- a/src/test/browser/fixtures.ts
+++ b/src/test/browser/fixtures.ts
@@ -1,6 +1,5 @@
 import { test as base } from "@playwright/test";
-import type { Server } from "http";
-import { createServer } from "http";
+import { type Server, createServer } from "http";
 import type { SetupServerApi } from "msw/node";
 import { setupServer } from "msw/node";
 import type { AddressInfo } from "net";
@@ -9,7 +8,7 @@ import path from "path";
 import { parse } from "url";
 import { defaultHandlers } from "../api/defaultHandlers";
 
-export const it = base.extend<
+export const test = base.extend<
   object,
   {
     baseUrl: string;

--- a/src/test/browser/utils.ts
+++ b/src/test/browser/utils.ts
@@ -1,0 +1,4 @@
+import type { test } from "./fixtures";
+
+export const getTabKey = (currentTest: typeof test) =>
+  currentTest.info().project.name === "webkit" ? "Alt+Tab" : "Tab";

--- a/src/test/browser/utils.ts
+++ b/src/test/browser/utils.ts
@@ -1,4 +1,2 @@
-import type { test } from "./fixtures";
-
-export const getTabKey = (currentTest: typeof test) =>
-  currentTest.info().project.name === "webkit" ? "Alt+Tab" : "Tab";
+export const getTabKey = (browserName: string) =>
+  browserName === "webkit" ? "Alt+Tab" : "Tab";


### PR DESCRIPTION
Tests for:

* Searching and making sure the url is updated
  * Also using keyboard navigation
* Clicking a gif and then the clipboard icon should copy the url to the clipboard
* Navigating through the gifs and copying the url to the clipboard should work with the keyboard

This addresses some of the points in #35 