### PR TITLE
Add top leve error boundary

### DIFF
--- a/app/error.spec.ts
+++ b/app/error.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from "@playwright/test";
+import { test } from "../src/test/browser/fixtures";
+import { tenorFeaturedHandler } from "../src/test/api/tenor";
+
+test("initial render", async ({ page, baseUrl, requestInterceptor }) => {
+  requestInterceptor.use(tenorFeaturedHandler(500));
+
+  await page.goto(baseUrl);
+
+  await expect(page).toHaveTitle("gifs.run - the fastest way to share gifs");
+
+  const logo = page.getByRole("img", { name: "gifs.run logo" });
+  await expect(logo).toBeVisible();
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  await expect(searchInput).toBeVisible();
+  await expect(searchInput).toBeEmpty();
+  await expect(searchInput).toBeFocused();
+  await expect(searchInput).toHaveAttribute("placeholder", "Search for a gif");
+
+  const searchButton = page.getByRole("button", { name: "Search" });
+  await expect(searchButton).toBeVisible();
+
+  const gifs = page.getByRole("button", {
+    name: /Load full preview of gif with description/,
+  });
+  await expect(gifs).toHaveCount(0);
+
+  const reloadButton = page.getByRole("button", {
+    name: "Reload and try again",
+  });
+  await expect(reloadButton).toBeVisible();
+
+  const errorImage = page.getByRole("img", { name: "an error occured" });
+  await expect(errorImage).toBeVisible();
+
+  const footer = page.getByRole("img", { name: "Powered by Tenor" });
+  await expect(footer).toBeVisible();
+});

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 "use client";
 
 import { useEffect } from "react";

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+
+const Error = ({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) => {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div>
+        <img
+          src="https://media.tenor.com/U5RwBfkG6t8AAAAd/elmo-flames.gif"
+          alt="an error occured"
+        />
+      </div>
+      <div className="p-10">
+        <button
+          className="rounded-md px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 hover:bg-gray-600"
+          onClick={() => reset()}
+        >
+          Reload and try again
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Error;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
+  quiet: true,
   reporter: "html",
   use: {
     trace: "on-first-retry",

--- a/src/test/browser/fixtures.ts
+++ b/src/test/browser/fixtures.ts
@@ -9,11 +9,8 @@ import { parse } from "url";
 import { defaultHandlers } from "../api/defaultHandlers";
 
 export const test = base.extend<
-  object,
-  {
-    baseUrl: string;
-    requestInterceptor: SetupServerApi;
-  }
+  { requestInterceptor: SetupServerApi },
+  { baseUrl: string }
 >({
   baseUrl: [
     // eslint-disable-next-line no-empty-pattern
@@ -46,9 +43,11 @@ export const test = base.extend<
   requestInterceptor: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
+      let requestInterceptor: SetupServerApi;
+
       await use(
         (() => {
-          const requestInterceptor = setupServer(...defaultHandlers);
+          requestInterceptor = setupServer(...defaultHandlers);
 
           requestInterceptor.listen({
             onUnhandledRequest: "error",
@@ -57,7 +56,9 @@ export const test = base.extend<
           return requestInterceptor;
         })(),
       );
+
+      requestInterceptor.close();
     },
-    { scope: "worker", auto: true },
+    { auto: true },
   ],
 });


### PR DESCRIPTION
Add top level error boundary for all uncatched errors.

Also added tests (#35)

Had to tweak the setup of the MSW request interceptor to not be scoped to a worker but to be setup for each individual test and properly closed to avoid interfering with other tests.

This fixes #49 