### PR TITLE
Test redirection if search without search term

### DIFF
--- a/app/search/page.spec.ts
+++ b/app/search/page.spec.ts
@@ -1,0 +1,8 @@
+import { expect } from "@playwright/test";
+import { test } from "../../src/test/browser/fixtures";
+
+test("redirection to landing page", async ({ page, baseUrl }) => {
+  await page.goto(`${baseUrl}/search`);
+
+  await expect(page).toHaveURL(baseUrl);
+});


### PR DESCRIPTION
Tests that if you go to /search only without a search term it redirects back to the landing page.

Ticks another box in #35 