### PR TITLE
Extend tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "test:browser": "playwright test",
+    "test:browser:ui": "playwright test --ui",
     "test:browser:install": "playwright install --with-deps --only-shell"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   quiet: true,
-  reporter: "html",
+  reporter: process.env.CI ? "dot" : "list",
   use: {
     trace: "on-first-retry",
   },

--- a/src/app/page.spec.ts
+++ b/src/app/page.spec.ts
@@ -39,6 +39,8 @@ test("selecting a gif and copying the url", async ({
 
   await clipboard.click();
 
+  await expect(page.getByText("Copied!")).toBeVisible();
+
   // https://github.com/microsoft/playwright/issues/34307
   if (!(browserName === "webkit" && process.env.CI)) {
     const clipboardText = await page.evaluate(() =>

--- a/src/app/page.spec.ts
+++ b/src/app/page.spec.ts
@@ -138,3 +138,23 @@ test("keyboard navigation of searching for gifs", async ({
 
   await expect(page).toHaveURL(`${baseUrl}/search/cats`);
 });
+
+test("keyboard shortcut to focus search", async ({
+  page,
+  baseUrl,
+  browserName,
+}) => {
+  await page.goto(`${baseUrl}/search/dog`);
+  const tabKey = getTabKey(browserName);
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  await expect(searchInput).toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  await expect(searchInput).not.toBeFocused();
+
+  await page.keyboard.press("ControlOrMeta+k");
+
+  await expect(searchInput).toBeFocused();
+});

--- a/src/app/search/[searchTerm]/page.spec.ts
+++ b/src/app/search/[searchTerm]/page.spec.ts
@@ -39,6 +39,8 @@ test("selecting a gif and copying the url", async ({
 
   await clipboard.click();
 
+  await expect(page.getByText("Copied!")).toBeVisible();
+
   // https://github.com/microsoft/playwright/issues/34307
   if (!(browserName === "webkit" && process.env.CI)) {
     const clipboardText = await page.evaluate(() =>

--- a/src/app/search/[searchTerm]/page.spec.ts
+++ b/src/app/search/[searchTerm]/page.spec.ts
@@ -26,7 +26,7 @@ test("scrolling to load more gifs", async ({
   requestInterceptor,
 }) => {
   requestInterceptor.use(
-    tenorSearchHandler(200, mockedSearchResponse, { delay: 100 }),
+    tenorSearchHandler(200, mockedSearchResponse, { delay: 200 }),
   );
 
   await page.goto(`${baseUrl}/search/dog`);
@@ -166,4 +166,24 @@ test("keyboard navigation of searching for gifs", async ({
   await page.keyboard.press("Enter");
 
   await expect(page).toHaveURL(`${baseUrl}/search/cats`);
+});
+
+test("keyboard shortcut to focus search", async ({
+  page,
+  baseUrl,
+  browserName,
+}) => {
+  await page.goto(`${baseUrl}/search/dog`);
+  const tabKey = getTabKey(browserName);
+
+  const searchInput = page.getByRole("textbox", { name: "search" });
+  await expect(searchInput).toBeFocused();
+
+  await page.keyboard.press(tabKey);
+
+  await expect(searchInput).not.toBeFocused();
+
+  await page.keyboard.press("ControlOrMeta+k");
+
+  await expect(searchInput).toBeFocused();
 });

--- a/src/components/Loeding.tsx
+++ b/src/components/Loeding.tsx
@@ -1,0 +1,11 @@
+import { IconSpinner } from "@/icons/IconSpinner";
+
+export const Loading = ({ isLoading = true }: { isLoading?: boolean }) => {
+  if (!isLoading) return;
+
+  return (
+    <div role="progressbar" aria-label="Loading" aria-busy>
+      <IconSpinner />
+    </div>
+  );
+};

--- a/src/components/MoreGifs.tsx
+++ b/src/components/MoreGifs.tsx
@@ -4,8 +4,8 @@ import { startTransition, useActionState, useEffect, useState } from "react";
 import { handleSearchGifs } from "@/actions";
 import type { Gif, GifsResult } from "@/types/Gif";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-import { IconSpinner } from "@/icons/IconSpinner";
 import { GifPreview } from "@/components/GifPreview";
+import { Loading } from "./Loeding";
 
 export const MoreGifs = ({
   searchTerm,
@@ -46,7 +46,7 @@ export const MoreGifs = ({
         />
       ))}
       <div ref={intersectionRef} className="flex justify-center w-full p-8">
-        {isPending && <IconSpinner />}
+        <Loading isLoading={isPending} />
       </div>
     </>
   );

--- a/src/test/api/tenor/index.ts
+++ b/src/test/api/tenor/index.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, http } from "msw";
+import { delay, HttpResponse, http, type DelayMode } from "msw";
 import { tenorBaseUrl } from "@/constants";
 import { mockedFeaturedResponse } from "@/test/api/tenor/mocks/featuredResponse";
 import { mockedSearchResponse } from "@/test/api/tenor/mocks/searchResponse";
@@ -18,8 +18,13 @@ export const tenorFeaturedHandler = (
 export const tenorSearchHandler = (
   status: number = 200,
   response: TenorResponse = mockedSearchResponse,
+  options?: { delay: DelayMode | number },
 ) =>
-  http.get(`${tenorBaseUrl}search`, () => {
+  http.get(`${tenorBaseUrl}search`, async () => {
+    if (options?.delay) {
+      await delay(options.delay);
+    }
+
     if (!isOkStatus(status)) return new HttpResponse(null, { status });
 
     return HttpResponse.json(response, { status });


### PR DESCRIPTION
Add tests for:

* That the toast appears after copy
* That load more on scroll works and shows the loader
* That the keyboard shortcut to go to the search works

Also: 
* Added a Loader component with better a11y and used it for the load more
* Added script for running Playwright in UI mode
* Tweaked the Playwright output, both in CI and locally

Fixes #69 