### PR TITLE
Handle error on scroll

### DIFF
--- a/src/components/MoreGifs.tsx
+++ b/src/components/MoreGifs.tsx
@@ -6,6 +6,7 @@ import type { Gif, GifsResult } from "@/types/Gif";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { GifPreview } from "@/components/GifPreview";
 import { Loading } from "./Loeding";
+import { toast } from "sonner";
 
 export const MoreGifs = ({
   searchTerm,
@@ -20,10 +21,23 @@ export const MoreGifs = ({
 
   const [gifs, onLoadMore, isPending] = useActionState<Gif[]>(
     async (previousState) => {
-      const newGifsResult = await handleSearchGifs(searchTerm, next);
-      setNext(newGifsResult.next);
+      try {
+        const newGifsResult = await handleSearchGifs(searchTerm, next);
 
-      return [...previousState, ...newGifsResult.gifs];
+        setNext(newGifsResult.next);
+        return [...previousState, ...newGifsResult.gifs];
+      } catch {
+        toast.error("Failed to load more!", {
+          description: "No more GIFs could be loaded",
+          duration: 300000,
+          action: {
+            label: "Try again",
+            onClick: onLoadMore,
+          },
+        });
+
+        return previousState;
+      }
     },
     [],
   );

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -21,6 +21,7 @@ export const Toaster = ({ ...props }: ToasterProps) => {
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground font-medium",
           title: "font-bold",
           icon: "pr-6",
+          error: "!border-2 !border-red-500",
         },
       }}
       {...props}


### PR DESCRIPTION
If loading the search page and the loading of the initial gifs works and you scroll down to the bottom more gifs will be loaded.
If that fails then the entire page blows up and the error page is served.

Instead:
* Handle the error and show a toast with error styling
* Allow retrying from the toast
* And reserve the error page for initial page load errors only

Fixes #67 